### PR TITLE
Fix insert option browser context menu bug ( https://github.com/deep-foundation/deepcase/issues/57 )

### DIFF
--- a/imports/cyto/hooks.tsx
+++ b/imports/cyto/hooks.tsx
@@ -196,7 +196,7 @@ export function useLinkInserting(elements = [], reactElements = [], focus, cy, e
     openInsertCard: (insertedLink: IInsertedLink) => {
       if (insertedLink) {
         setInsertingLink(insertedLink);
-        if (cy) {
+        if (cy) {// TODO: ERR: cy always undefined
           const el = cy.$('#insert-link-card');
           el.unlock();
           if (!insertedLink.from && !insertedLink.to) {
@@ -763,7 +763,8 @@ export function useCyInitializer({
         {
           content: 'insert',
           select: function(el, ev){
-            openInsertCard({ position: ev.position, from: 0, to: 0 });
+            // TODO: use insert card size instead or change anchor of InsertCard component from center to top-left
+            openInsertCard({ position: {x: ev.position.x + 190, y: ev.position.y + 150}, from: 0, to: 0 });
           }
         },
         {

--- a/imports/cyto/hooks.tsx
+++ b/imports/cyto/hooks.tsx
@@ -763,8 +763,9 @@ export function useCyInitializer({
         {
           content: 'insert',
           select: function(el, ev){
-            // TODO: use insert card size instead or change anchor of InsertCard component from center to top-left
-            openInsertCard({ position: {x: ev.position.x + 190, y: ev.position.y + 150}, from: 0, to: 0 });
+            setTimeout(()=>{
+              openInsertCard({ position: ev.position, from: 0, to: 0 });
+            },1);
           }
         },
         {


### PR DESCRIPTION
Propagation of mouseUp event in InsertCard modal frame was reason of [this bug]( https://github.com/deep-foundation/deepcase/issues/57) . 
I fixed it through replace relative initial creation position of modal window. 
Futhermore it fixed enoing case when InsertCard modal window opens over top menu and was not clickable!

**before** (_click was on number 3 in 937 label_): 
![изображение](https://user-images.githubusercontent.com/4994868/232099999-48e798f9-cd85-413f-adaf-7c95c5c93caa.png)


**now** (_click was on number 3 in 937 label_):
![изображение](https://user-images.githubusercontent.com/4994868/232099323-87643fc0-0dab-4c81-8a55-95edfd0a666f.png)


I think, this bug is special case of **more general situation: all components placed over canvas ( like top menu, packager button e.t.c ) allow open browser context menu on right mouse click.**
I ready to get it in work, but outside of that small bugfix.


-------
P.S. I found another bug into placement behavior: If InsertCard frame still opened, new Insert command not moved this onto click position. That conditioned permanent undefinite state of "cy" variable ( _see imports/cyto/hooks.tsx line 199 for details_ ).
